### PR TITLE
Removed Trademark declaration from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ the web rendering and browser/server communication automatically.
 ## Notes
 
 - This is an unofficial fork. The official website is [http://thinwire.sourceforge.net][1]
-- ThinWire is a registered trademark of Custom Credit Systems
 - The best documentation available is in the form of an [ebook][2]
   co-authored by yours truly
 


### PR DESCRIPTION
Custom Credit Systems no longer exists, and their acquirers most certainly did not renew this trademark. (http://tmsearch.uspto.gov/bin/showfield?f=doc&state=4810:xigqz4.2.1)

I'll bet you did not expect to see a pull request today.